### PR TITLE
fix ios isAllDay calculation

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -65,7 +65,7 @@ public class CapacitorCalendar: CAPPlugin {
                     event.isAllDay = allDay
                 } else {
                     let duration = Int(endDate - startDate);
-                    let moduloDay = duration % (60 * 60 * 24);
+                    let moduloDay = (duration / 1000) % (60 * 60 * 24);
                     if (moduloDay == 0) {
                         event.isAllDay = true;
                         event.endDate = Date(timeIntervalSince1970: (endDate / 1000) - 1)
@@ -147,7 +147,7 @@ public class CapacitorCalendar: CAPPlugin {
                     event.isAllDay = allDay
                 } else {
                     let duration = Int(endDate - startDate);
-                    let moduloDay = duration % (60 * 60 * 24);
+                    let moduloDay = (duration / 1000) % (60 * 60 * 24);
                     if (moduloDay == 0) {
                         event.isAllDay = true;
                         event.endDate = Date(timeIntervalSince1970: (endDate / 1000) - 1)


### PR DESCRIPTION
there is another bug in ios, the calculation for isAllDay didn't worked correctly.

example for wrong result:
```
startDate = 1667840400000 (Mon Nov 07 2022 18:00:00 GMT+0100 (CET))
endDate   = 1667851200000 (Mon Nov 07 2022 21:00:00 GMT+0100 (CET))

1667851200000 - 1667840400000 = 10800000
10800000 % (60 * 60 * 24) = 0
```