### PR TITLE
Remove errored dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.android.support:appcompat-v7:28'
+    //implementation 'com.android.support:appcompat-v7:28'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
There is an error in the build.gradle file, the dependency cannot be resolved and the build fails.
This pull request annotates the affected line, and removes the error.